### PR TITLE
fix(timeout): bump timeout from 59 to 120 minutes

### DIFF
--- a/proctoru/settings.py
+++ b/proctoru/settings.py
@@ -1,4 +1,5 @@
 from django.conf import settings
 
 
-PROCTORU_EXAM_AWAY_TIMEOUT = getattr(settings, 'PROCTORU_EXAM_AWAY_TIMEOUT', -59)
+PROCTORU_EXAM_AWAY_TIMEOUT = getattr(settings, 'PROCTORU_EXAM_AWAY_TIMEOUT', -240)
+


### PR DESCRIPTION
Validation sometimes takes more than 59 minutes and this generates a lot of support requests to reactivate the student's proctoru registration. Let's bump it to 120 minutes.

Planio #3991